### PR TITLE
Fix vector url in homebrew formula

### DIFF
--- a/Formula/vector.rb
+++ b/Formula/vector.rb
@@ -1,7 +1,7 @@
 class Vector < Formula
   desc "A High-Performance Log, Metrics, and Events Router"
   homepage "https://github.com/timberio/vector"
-  url "https://packages.timber.io/vector/0.11.0/vector-0.11.0-x86_64-apple-darwin.tar.gz"
+  url "https://packages.timber.io/vector/0.11.0/vector-x86_64-apple-darwin.tar.gz"
   version "0.11.0"
   sha256 "af90177328047a3b79fa15647ea026c83ccb7f3d54a44e968edea49a71e70ee5"
   head "https://github.com/timberio/vector.git"


### PR DESCRIPTION
Homebrew is currently failing to install `vector`:

```
❯ brew tap timberio/brew && brew install vector
Updating Homebrew...
Updating Homebrew...
==> Installing vector from timberio/brew
==> Downloading https://packages.timber.io/vector/0.11.0/vector-0.11.0-x86_64-apple-darwin.tar.gz
#=#=#                                                                         
curl: (22) The requested URL returned error: 404 
Error: Failed to download resource "vector"
Download failed: https://packages.timber.io/vector/0.11.0/vector-0.11.0-x86_64-apple-darwin.tar.gz
```

Looks like the package naming scheme changed?

I'm not sure about the [sha256](https://github.com/timberio/homebrew-brew/pull/4/files#diff-46651c84f6daae43b83c6c2a039a0c4f708e56656821203c33ef54dadb06350eR6) either, I get a different one when running that locally:
```
 openssl dgst -sha256 vector-x86_64-apple-darwin.tar.gz
SHA256(vector-x86_64-apple-darwin.tar.gz)= d7c934bf939803015c510f3375ecc40e9f7d3e36d23a16fc20552e60e871667a
```