### PR TITLE
Fix Vector 0.12.1 SHA256 checksum

### DIFF
--- a/Formula/vector.rb
+++ b/Formula/vector.rb
@@ -3,7 +3,7 @@ class Vector < Formula
   homepage "https://github.com/timberio/vector"
   url "https://packages.timber.io/vector/0.12.1/vector-0.12.1-x86_64-apple-darwin.tar.gz"
   version "0.12.1"
-  sha256 "af90177328047a3b79fa15647ea026c83ccb7f3d54a44e968edea49a71e70ee5"
+  sha256 "876271186d76d9f32d66fe19f7840747fce2aab249ea9fe903d9c05712bd7503"
   head "https://github.com/timberio/vector.git"
 
   def install


### PR DESCRIPTION
Vector 0.12.1 fails to upgrade via brew:
```
$ brew tap timberio/brew && brew upgrade vector
Updating Homebrew...
==> Upgrading 1 outdated package:
timberio/brew/vector 0.12.0 -> 0.12.1
==> Upgrading timberio/brew/vector 0.12.0 -> 0.12.1 
==> Downloading https://packages.timber.io/vector/0.12.1/vector-0.12.1-x86_64-apple-darwin.tar.gz
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: af90177328047a3b79fa15647ea026c83ccb7f3d54a44e968edea49a71e70ee5
  Actual: 876271186d76d9f32d66fe19f7840747fce2aab249ea9fe903d9c05712bd7503
    File: /Users/mcastellini/Library/Caches/Homebrew/downloads/c8acd097abe7d050ac35c046d562033e10e94e0f042fe0da6bc2a8a39765af67--vector-0.12.1-x86_64-apple-darwin.tar.gz
To retry an incomplete download, remove the file above.
```

Apparently the downloaded tarball SHA256 hash differs from the one provided in the formula, this PR aligns the SHA256 in the formula with the one computed on the downloaded tarball
```
$ curl -O https://packages.timber.io/vector/0.12.1/vector-0.12.1-x86_64-apple-darwin.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 22.1M  100 22.1M    0     0  3577k      0  0:00:06  0:00:06 --:--:-- 4148k
$ sha256sum vector-0.12.1-x86_64-apple-darwin.tar.gz 
876271186d76d9f32d66fe19f7840747fce2aab249ea9fe903d9c05712bd7503  vector-0.12.1-x86_64-apple-darwin.tar.gz
```