### PR TITLE
Fix Vector 0.12.2 SHA256 checksum

### DIFF
--- a/Formula/vector.rb
+++ b/Formula/vector.rb
@@ -3,7 +3,7 @@ class Vector < Formula
   homepage "https://github.com/timberio/vector"
   url "https://packages.timber.io/vector/0.12.2/vector-0.12.2-x86_64-apple-darwin.tar.gz"
   version "0.12.2"
-  sha256 "af90177328047a3b79fa15647ea026c83ccb7f3d54a44e968edea49a71e70ee5"
+  sha256 "fdbbb026b9f6c577e0fadcb0e4823e7655af5e640835e54634062e97170ad11c"
   head "https://github.com/timberio/vector.git"
 
   def install


### PR DESCRIPTION
Closes #6.

Vector 0.12.2 fails to upgrade via brew:
```
$ brew tap timberio/brew && brew upgrade vector
Updating Homebrew...
==> Upgrading 1 outdated package:
timberio/brew/vector 0.12.1 -> 0.12.2
==> Upgrading timberio/brew/vector 0.12.1 -> 0.12.2 
==> Downloading https://packages.timber.io/vector/0.12.2/vector-0.12.2-x86_64-apple-darwin.tar.gz
######################################################################## 100.0%
Error: SHA256 mismatch
Expected: af90177328047a3b79fa15647ea026c83ccb7f3d54a44e968edea49a71e70ee5
  Actual: fdbbb026b9f6c577e0fadcb0e4823e7655af5e640835e54634062e97170ad11c
```

Apparently the downloaded tarball SHA256 hash differs from the one provided in the formula, this PR aligns the SHA256 in the formula with the one computed on the downloaded tarball
```
$ curl -O https://packages.timber.io/vector/0.12.2/vector-0.12.2-x86_64-apple-darwin.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21.5M  100 21.5M    0     0  3158k      0  0:00:06  0:00:06 --:--:-- 3473k
$ sha256sum vector-0.12.2-x86_64-apple-darwin.tar.gz 
fdbbb026b9f6c577e0fadcb0e4823e7655af5e640835e54634062e97170ad11c  vector-0.12.2-x86_64-apple-darwin.tar.gz
```